### PR TITLE
Fix obtention of `rx_bitrate` and `tx_bitrate`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,5 @@ repository = "https://github.com/Eonm/nl80211"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-buffering = { version = "0.3.2",  features = ["copy"] }
 neli = "0.4.3-r1"
 hex = "0.4.0"

--- a/README.md
+++ b/README.md
@@ -41,8 +41,8 @@ fn main() -> Result<(), Box<dyn Error>> {
       // average signal : -61 dBm
       // rx packets : 148983
       // tx packets : 46335
-      // rx bitrate : 60 Mb/s
-      // tx bitrate : 140 Mb/s
+      // rx bitrate : 60.0 Mb/s
+      // tx bitrate : 140.0 Mb/s
       // tx retries : 12578
       // tx failed : 2
   }
@@ -107,8 +107,8 @@ fn main() -> Result<(), Box<dyn Error>> {
       // average signal : -61 dBm
       // rx packets : 148983
       // tx packets : 46335
-      // rx bitrate : 60 Mb/s
-      // tx bitrate : 140 Mb/s
+      // rx bitrate : 60.0 Mb/s
+      // tx bitrate : 140.0 Mb/s
       // tx retries : 12578
       // tx failed : 2
   }

--- a/src/attr.rs
+++ b/src/attr.rs
@@ -481,7 +481,6 @@ impl_var_trait!(
     FrequencyAttrMax          => 17
 );
 
-
 impl_var_trait!(
     /// nl80211BitrateAttr
     ///
@@ -587,7 +586,6 @@ impl_var_trait!(
     UserRegHintCellBase => 1,
     UserRegHintIndoor   => 2
 );
-
 
 impl_var_trait!(
     /// nl80211SurveyInfo

--- a/src/bss.rs
+++ b/src/bss.rs
@@ -1,9 +1,9 @@
-use std::fmt;
 use crate::attr::Nl80211Attr;
 use crate::attr::Nl80211Bss;
 use crate::nl80211traits::ParseNlAttr;
 use crate::parse_attr::{parse_hex, parse_i32, parse_u16, parse_u32};
 use neli::nlattr::AttrHandle;
+use std::fmt;
 
 /// A struct representing a BSS (Basic Service Set)
 #[derive(Debug, Clone, PartialEq)]
@@ -87,17 +87,13 @@ impl ParseNlAttr for Bss {
                         Nl80211Bss::BssBeaconInterval => {
                             self.beacon_interval = Some(sub_attr.payload.clone())
                         }
-                        Nl80211Bss::BssFrequency => {
-                            self.frequency = Some(sub_attr.payload.clone())
-                        }
+                        Nl80211Bss::BssFrequency => self.frequency = Some(sub_attr.payload.clone()),
                         Nl80211Bss::BssSeenMsAgo => {
                             self.seen_ms_ago = Some(sub_attr.payload.clone())
                         }
                         Nl80211Bss::BssStatus => self.status = Some(sub_attr.payload.clone()),
                         Nl80211Bss::BssBssid => self.bssid = Some(sub_attr.payload.clone()),
-                        Nl80211Bss::BssSignalMbm => {
-                            self.signal = Some(sub_attr.payload.clone())
-                        }
+                        Nl80211Bss::BssSignalMbm => self.signal = Some(sub_attr.payload.clone()),
                         _ => (),
                     }
                 }

--- a/src/bss.rs
+++ b/src/bss.rs
@@ -80,30 +80,27 @@ impl ParseNlAttr for Bss {
     fn parse(&mut self, handle: AttrHandle<Nl80211Attr>) -> Bss {
         for attr in handle.iter() {
             println!("{:?}", attr);
-            match attr.nla_type {
-                Nl80211Attr::AttrBss => {
-                    let sub_handle = attr.get_nested_attributes::<Nl80211Bss>().unwrap();
-                    for sub_attr in sub_handle.iter() {
-                        match sub_attr.nla_type {
-                            Nl80211Bss::BssBeaconInterval => {
-                                self.beacon_interval = Some(sub_attr.payload.clone())
-                            }
-                            Nl80211Bss::BssFrequency => {
-                                self.frequency = Some(sub_attr.payload.clone())
-                            }
-                            Nl80211Bss::BssSeenMsAgo => {
-                                self.seen_ms_ago = Some(sub_attr.payload.clone())
-                            }
-                            Nl80211Bss::BssStatus => self.status = Some(sub_attr.payload.clone()),
-                            Nl80211Bss::BssBssid => self.bssid = Some(sub_attr.payload.clone()),
-                            Nl80211Bss::BssSignalMbm => {
-                                self.signal = Some(sub_attr.payload.clone())
-                            }
-                            _ => (),
+            if attr.nla_type == Nl80211Attr::AttrBss {
+                let sub_handle = attr.get_nested_attributes::<Nl80211Bss>().unwrap();
+                for sub_attr in sub_handle.iter() {
+                    match sub_attr.nla_type {
+                        Nl80211Bss::BssBeaconInterval => {
+                            self.beacon_interval = Some(sub_attr.payload.clone())
                         }
+                        Nl80211Bss::BssFrequency => {
+                            self.frequency = Some(sub_attr.payload.clone())
+                        }
+                        Nl80211Bss::BssSeenMsAgo => {
+                            self.seen_ms_ago = Some(sub_attr.payload.clone())
+                        }
+                        Nl80211Bss::BssStatus => self.status = Some(sub_attr.payload.clone()),
+                        Nl80211Bss::BssBssid => self.bssid = Some(sub_attr.payload.clone()),
+                        Nl80211Bss::BssSignalMbm => {
+                            self.signal = Some(sub_attr.payload.clone())
+                        }
+                        _ => (),
                     }
                 }
-                _ => (),
             }
         }
         self.to_owned()

--- a/src/cmd.rs
+++ b/src/cmd.rs
@@ -2,7 +2,7 @@ use neli::consts::Cmd;
 use neli::{impl_var, impl_var_base, impl_var_trait};
 
 // https://github.com/mdlayher/wifi/blob/b1436901ddee2ea3ee8782a440a084e457615766/internal/nl80211/const.go
-    impl_var_trait!(
+impl_var_trait!(
     /// nl80211Commands
     ///
     /// Enumeration from nl80211/nl80211.h:880

--- a/src/interface.rs
+++ b/src/interface.rs
@@ -1,4 +1,3 @@
-use std::fmt;
 use crate::attr::*;
 use crate::nl80211traits::ParseNlAttr;
 use crate::parse_attr::parse_u32;
@@ -6,6 +5,7 @@ use crate::parse_attr::parse_u64;
 use crate::socket::Socket;
 use crate::station::Station;
 use neli::nlattr::AttrHandle;
+use std::fmt;
 
 use crate::parse_attr::{parse_hex, parse_string};
 

--- a/src/interface.rs
+++ b/src/interface.rs
@@ -91,15 +91,15 @@ impl fmt::Display for Interface {
         let mut result = Vec::new();
 
         if let Some(ssid) = &self.ssid {
-            result.push(format!("essid : {}", parse_string(&ssid)))
+            result.push(format!("essid : {}", parse_string(ssid)))
         };
 
         if let Some(mac) = &self.mac {
-            result.push(format!("mac : {}", parse_hex(&mac)))
+            result.push(format!("mac : {}", parse_hex(mac)))
         };
 
         if let Some(name) = &self.name {
-            result.push(format!("interface : {}", parse_string(&name)))
+            result.push(format!("interface : {}", parse_string(name)))
         };
 
         if let Some(frequency) = &self.frequency {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -82,8 +82,8 @@
 //!       // average signal : -61 dBm
 //!       // rx packets : 148983
 //!       // tx packets : 46335
-//!       // rx bitrate : 60 Mb/s
-//!       // tx bitrate : 140 Mb/s
+//!       // rx bitrate : 650.0 Mb/s
+//!       // tx bitrate : 866.7 Mb/s
 //!       // tx retries : 12578
 //!       // tx failed : 2
 //!   }

--- a/src/parse_attr.rs
+++ b/src/parse_attr.rs
@@ -1,7 +1,7 @@
 use std::convert::TryInto;
 
 /// Parse a vec of bytes as hex String
-pub fn parse_hex(input: &Vec<u8>) -> String {
+pub fn parse_hex(input: &[u8]) -> String {
     let value: Vec<char> = hex::encode_upper(input).chars().collect();
     let split = value
         .chunks(2)
@@ -12,12 +12,12 @@ pub fn parse_hex(input: &Vec<u8>) -> String {
 }
 
 /// Parse a vec of bytes as a String
-pub fn parse_string(input: &Vec<u8>) -> String {
-    String::from_utf8_lossy(&input).to_owned().to_string()
+pub fn parse_string(input: &[u8]) -> String {
+    String::from_utf8_lossy(input).to_owned().to_string()
 }
 
 /// Parse a vec of bytes as u8
-pub fn parse_u8(input: &Vec<u8>) -> u8 {
+pub fn parse_u8(input: &[u8]) -> u8 {
     let to_array =
         |slice: &[u8]| -> [u8; 1] { slice.try_into().expect("slice with incorrect length") };
 
@@ -25,7 +25,7 @@ pub fn parse_u8(input: &Vec<u8>) -> u8 {
 }
 
 /// Parse a vec of bytes as i8
-pub fn parse_i8(input: &Vec<u8>) -> i8 {
+pub fn parse_i8(input: &[u8]) -> i8 {
     let to_array =
         |slice: &[u8]| -> [u8; 1] { slice.try_into().expect("slice with incorrect length") };
 
@@ -33,7 +33,7 @@ pub fn parse_i8(input: &Vec<u8>) -> i8 {
 }
 
 /// Parse a vec of bytes as u16
-pub fn parse_u16(input: &Vec<u8>) -> u16 {
+pub fn parse_u16(input: &[u8]) -> u16 {
     let to_array =
         |slice: &[u8]| -> [u8; 2] { slice.try_into().expect("slice with incorrect length") };
 
@@ -41,7 +41,7 @@ pub fn parse_u16(input: &Vec<u8>) -> u16 {
 }
 
 /// Parse a vec of bytes as u32
-pub fn parse_u32(input: &Vec<u8>) -> u32 {
+pub fn parse_u32(input: &[u8]) -> u32 {
     let to_array =
         |slice: &[u8]| -> [u8; 4] { slice.try_into().expect("slice with incorrect length") };
 
@@ -49,7 +49,7 @@ pub fn parse_u32(input: &Vec<u8>) -> u32 {
 }
 
 /// Parse a vec of bytes as i32
-pub fn parse_i32(input: &Vec<u8>) -> i32 {
+pub fn parse_i32(input: &[u8]) -> i32 {
     let to_array =
         |slice: &[u8]| -> [u8; 4] { slice.try_into().expect("slice with incorrect length") };
 
@@ -57,7 +57,7 @@ pub fn parse_i32(input: &Vec<u8>) -> i32 {
 }
 
 /// Parse a vec of bytes as u64
-pub fn parse_u64(input: &Vec<u8>) -> u64 {
+pub fn parse_u64(input: &[u8]) -> u64 {
     let to_array =
         |slice: &[u8]| -> [u8; 8] { slice.try_into().expect("slice with incorrect length") };
 

--- a/src/socket/mod.rs
+++ b/src/socket/mod.rs
@@ -83,7 +83,7 @@ impl Socket {
 
         Ok(Self {
             sock: nl80211sock,
-            family_id: family_id,
+            family_id,
         })
     }
 
@@ -158,7 +158,7 @@ impl Socket {
     /// #   Ok(())
     /// # }
     ///```
-    pub fn get_station_info(&mut self, interface_attr_if_index: &Vec<u8>) -> Result<Station, neli::err::NlError>  {
+    pub fn get_station_info(&mut self, interface_attr_if_index: &[u8]) -> Result<Station, neli::err::NlError>  {
         let nl80211sock = &mut self.sock;
 
         let mut attrs: Vec<Nlattr<Nl80211Attr, Vec<u8>>> = vec![];
@@ -190,10 +190,10 @@ impl Socket {
                     },
             };
         }
-        return Ok(Station::default())
+        Ok(Station::default())
     }
 
-    pub fn get_bss_info(&mut self, interface_attr_if_index: &Vec<u8>) -> Result<Bss, neli::err::NlError> {
+    pub fn get_bss_info(&mut self, interface_attr_if_index: &[u8]) -> Result<Bss, neli::err::NlError> {
         let nl80211sock = &mut self.sock;
 
         let mut attrs: Vec<Nlattr<Nl80211Attr, Vec<u8>>> = vec![];

--- a/src/socket/mod.rs
+++ b/src/socket/mod.rs
@@ -1,16 +1,16 @@
 use crate::bss::Bss;
-use crate::station::Station;
 use crate::nl80211traits::ParseNlAttr;
+use crate::station::Station;
 // use crate::station::parse_station;
-use neli::consts::{NlFamily,NlmF,Nlmsg};
-use neli::socket::NlSocket;
-use neli::nl::Nlmsghdr;
-use neli::genl::Genlmsghdr;
-use crate::consts::{NL_80211_GENL_NAME, NL_80211_GENL_VERSION};
 use crate::attr::Nl80211Attr;
 use crate::cmd::Nl80211Cmd;
+use crate::consts::{NL_80211_GENL_NAME, NL_80211_GENL_VERSION};
 use crate::interface::Interface;
+use neli::consts::{NlFamily, NlmF, Nlmsg};
+use neli::genl::Genlmsghdr;
+use neli::nl::Nlmsghdr;
 use neli::nlattr::Nlattr;
+use neli::socket::NlSocket;
 
 /// A generic netlink socket to send commands and receive messages
 pub struct Socket {
@@ -69,10 +69,8 @@ impl Socket {
     /// # }
     /// ```
     pub fn connect() -> Result<Self, neli::err::NlError> {
-        let family_id = {
-            NlSocket::new(NlFamily::Generic, true)?
-                .resolve_genl_family(NL_80211_GENL_NAME)?
-        };
+        let family_id =
+            { NlSocket::new(NlFamily::Generic, true)?.resolve_genl_family(NL_80211_GENL_NAME)? };
 
         let track_seq = true;
         let mut nl80211sock = NlSocket::new(NlFamily::Generic, track_seq)?;
@@ -130,7 +128,7 @@ impl Socket {
                 _ => {
                     let handle = response.nl_payload.get_attr_handle();
                     interfaces.push(Interface::default().parse(handle));
-                },
+                }
             };
         }
 
@@ -158,11 +156,18 @@ impl Socket {
     /// #   Ok(())
     /// # }
     ///```
-    pub fn get_station_info(&mut self, interface_attr_if_index: &[u8]) -> Result<Station, neli::err::NlError>  {
+    pub fn get_station_info(
+        &mut self,
+        interface_attr_if_index: &[u8],
+    ) -> Result<Station, neli::err::NlError> {
         let nl80211sock = &mut self.sock;
 
         let mut attrs: Vec<Nlattr<Nl80211Attr, Vec<u8>>> = vec![];
-        let new_attr= Nlattr::new(None, Nl80211Attr::AttrIfindex, interface_attr_if_index.to_owned())?;
+        let new_attr = Nlattr::new(
+            None,
+            Nl80211Attr::AttrIfindex,
+            interface_attr_if_index.to_owned(),
+        )?;
         attrs.push(new_attr);
 
         let genlhdr = Genlmsghdr::new(Nl80211Cmd::CmdGetStation, NL_80211_GENL_VERSION, attrs)?;
@@ -182,23 +187,30 @@ impl Socket {
 
         while let Some(Ok(response)) = iter.next() {
             match response.nl_type {
-                    Nlmsg::Error => panic!("Error"),
-                    Nlmsg::Done => break,
-                    _ => {
-                        let  handle = response.nl_payload.get_attr_handle();
-                        return Ok(Station::default().parse(handle));
-                    },
+                Nlmsg::Error => panic!("Error"),
+                Nlmsg::Done => break,
+                _ => {
+                    let handle = response.nl_payload.get_attr_handle();
+                    return Ok(Station::default().parse(handle));
+                }
             };
         }
         Ok(Station::default())
     }
 
-    pub fn get_bss_info(&mut self, interface_attr_if_index: &[u8]) -> Result<Bss, neli::err::NlError> {
+    pub fn get_bss_info(
+        &mut self,
+        interface_attr_if_index: &[u8],
+    ) -> Result<Bss, neli::err::NlError> {
         let nl80211sock = &mut self.sock;
 
         let mut attrs: Vec<Nlattr<Nl80211Attr, Vec<u8>>> = vec![];
 
-        let new_attr= Nlattr::new(None, Nl80211Attr::AttrIfindex, interface_attr_if_index.to_owned())?;
+        let new_attr = Nlattr::new(
+            None,
+            Nl80211Attr::AttrIfindex,
+            interface_attr_if_index.to_owned(),
+        )?;
         attrs.push(new_attr);
 
         let genlhdr = Genlmsghdr::new(Nl80211Cmd::CmdGetScan, NL_80211_GENL_VERSION, attrs)?;
@@ -218,14 +230,14 @@ impl Socket {
 
         while let Some(Ok(response)) = iter.next() {
             match response.nl_type {
-                    Nlmsg::Error => panic!("Error"),
-                    Nlmsg::Done => break,
-                    _ => {
-                        let  handle = response.nl_payload.get_attr_handle();
-                        return Ok(Bss::default().parse(handle))
-                    }
+                Nlmsg::Error => panic!("Error"),
+                Nlmsg::Done => break,
+                _ => {
+                    let handle = response.nl_payload.get_attr_handle();
+                    return Ok(Bss::default().parse(handle));
                 }
             }
+        }
         Ok(Bss::default())
     }
 

--- a/src/station.rs
+++ b/src/station.rs
@@ -1,8 +1,8 @@
-use std::fmt;
 use crate::attr::{Nl80211Attr, Nl80211RateInfo, Nl80211StaInfo};
 use crate::nl80211traits::*;
 use crate::parse_attr::{parse_hex, parse_i8, parse_u32};
 use neli::nlattr::AttrHandle;
+use std::fmt;
 
 /// A struct representing a remote station (Access Point)
 #[derive(Clone, Debug, PartialEq)]

--- a/src/station.rs
+++ b/src/station.rs
@@ -89,11 +89,8 @@ impl ParseNlAttr for Station {
                                 let bit_rate_handle =
                                     sub_attr.get_nested_attributes::<Nl80211RateInfo>().unwrap();
                                 for sub_sub_attr in bit_rate_handle.iter() {
-                                    match sub_sub_attr.nla_type {
-                                        Nl80211RateInfo::RateInfoBitrate32 => {
-                                            self.rx_bitrate = Some(sub_sub_attr.payload.clone())
-                                        }
-                                        _ => (),
+                                    if sub_sub_attr.nla_type == Nl80211RateInfo::RateInfoBitrate32 {
+                                        self.rx_bitrate = Some(sub_sub_attr.payload.clone())
                                     }
                                 }
                             }
@@ -101,11 +98,8 @@ impl ParseNlAttr for Station {
                                 let bit_rate_handle =
                                     sub_attr.get_nested_attributes::<Nl80211RateInfo>().unwrap();
                                 for sub_sub_attr in bit_rate_handle.iter() {
-                                    match sub_sub_attr.nla_type {
-                                        Nl80211RateInfo::RateInfoBitrate32 => {
-                                            self.tx_bitrate = Some(sub_sub_attr.payload.clone())
-                                        }
-                                        _ => (),
+                                    if sub_sub_attr.nla_type == Nl80211RateInfo::RateInfoBitrate32 {
+                                        self.tx_bitrate = Some(sub_sub_attr.payload.clone())
                                     }
                                 }
                             }


### PR DESCRIPTION
The previous implementation searched for a `nla_type` of`StaInfoRxBytes`, which is of the wrong enum type, and effectively maps to `RateInfoMcs`, when it should be mapping to `RateInfoBitrate` or `RateInfoBitrate32`. I opted for the latter.
    
The 32-bit bitrate was introduced almost 10 years ago, so I don't believe it's necessary to account for the possibility of it not being there, like `iw` does.